### PR TITLE
Data Seeding

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -216,7 +216,7 @@ jobs:
             # Seed demo data if explicitly enabled
             if [ "${{ env.DEMO_SEED }}" = "true" ]; then
               echo "Seeding demo data..."
-              python manage.py seed_demo_data || { echo 'Seeding failed'; exit 1; }
+              DEMO_SEED=${{ env.DEMO_SEED }} python manage.py seed_demo_data || { echo 'Seeding failed'; exit 1; }
             else
               echo "Demo seeding skipped (DEMO_SEED != true)"
             fi

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -159,6 +159,11 @@ jobs:
             echo "ERROR: Attempted to deploy from an unsupported branch: ${{ github.ref_name }}"
             exit 1
           fi
+          if [[ "${{ github.ref_name }}" == "development" ]]; then
+            echo "DEMO_SEED=true" >> $GITHUB_ENV
+          else
+            echo "DEMO_SEED=false" >> $GITHUB_ENV
+          fi
 
       - name: Deploy with rollback on failure
         uses: appleboy/ssh-action@334f9259f2f8eb3376d33fa4c684fff373f2c2a6 # v0.1.10
@@ -204,6 +209,17 @@ jobs:
 
             echo "Installing requirements..."
             pip install -r requirements.txt
+
+            echo "Applying database migrations..."
+            python manage.py migrate --noinput
+
+            # Seed demo data if explicitly enabled
+            if [ "${{ env.DEMO_SEED }}" = "true" ]; then
+              echo "Seeding demo data..."
+              python manage.py seed_demo_data || { echo 'Seeding failed'; exit 1; }
+            else
+              echo "Demo seeding skipped (DEMO_SEED != true)"
+            fi
 
             echo "Restarting service..."
             sudo systemctl restart ${{ env.SERVICE_NAME }}

--- a/db_pricing/management/commands/seed_demo_data.py
+++ b/db_pricing/management/commands/seed_demo_data.py
@@ -1,0 +1,380 @@
+from django.core.management.base import BaseCommand
+from django.db import transaction
+from django.utils import timezone
+from django.conf import settings
+import os
+from datetime import timedelta
+
+from db_pricing.models import (
+    GemilangProduct,
+    Mitra10Product,
+    TokopediaProduct,
+    DepoBangunanProduct,
+    JuraganMaterialProduct,
+    PriceAnomaly,
+)
+
+
+CATEGORY_BUILDING_MATERIALS = "Building Materials"
+CATEGORY_HARDWARE = "Hardware"
+CATEGORY_PAINTS = "Paints"
+CATEGORY_TILES = "Tiles"
+CATEGORY_AGGREGATES = "Aggregates"
+
+# Reusable demo product URLs (avoid duplicated literals)
+GEMILANG_P1 = "https://demo.example/gemilang/product-1"
+MITRA10_P1 = "https://demo.example/mitra10/product-1"
+MITRA10_P2 = "https://demo.example/mitra10/product-2"
+TOKOPEDIA_P1 = "https://demo.example/tokopedia/product-1"
+DEPO_P1 = "https://demo.example/depobangunan/product-1"
+
+# Demo products (use stable demo URLs)
+DEMO_PRODUCTS = [
+    {
+        "model": GemilangProduct,
+        "url": GEMILANG_P1,
+        "name": "Demo Nails 1kg",
+        "price": 10000,
+        "unit": "kg",
+        "location": "Jakarta",
+        "category": CATEGORY_HARDWARE,
+    },
+    {
+        "model": GemilangProduct,
+        "url": "https://demo.example/gemilang/product-2",
+        "name": "Demo Screws 500g",
+        "price": 8000,
+        "unit": "pack",
+        "location": "Jakarta",
+        "category": CATEGORY_BUILDING_MATERIALS,
+    },
+    {
+        "model": GemilangProduct,
+        "url": "https://demo.example/gemilang/product-3",
+        "name": "Demo Nails 1kg - Bandung",
+        "price": 10500,
+        "unit": "kg",
+        "location": "Bandung",
+        "category": CATEGORY_HARDWARE,
+    },
+    {
+        "model": GemilangProduct,
+        "url": "https://demo.example/gemilang/product-4",
+        "name": "Demo Screws 500g - Bandung",
+        "price": 8200,
+        "unit": "pack",
+        "location": "Bandung",
+        "category": CATEGORY_BUILDING_MATERIALS,
+    },
+    {
+        "model": Mitra10Product,
+        "url": MITRA10_P1,
+        "name": "Demo Cement 40kg",
+        "price": 75000,
+        "unit": "pack",
+        "location": "Bandung",
+        "category": CATEGORY_BUILDING_MATERIALS,
+    },
+    {
+        "model": Mitra10Product,
+        "url": MITRA10_P2,
+        "name": "Demo Cement 40kg - Jakarta",
+        "price": 76000,
+        "unit": "pack",
+        "location": "Jakarta",
+        "category": CATEGORY_BUILDING_MATERIALS,
+    },
+    {
+        "model": Mitra10Product,
+        "url": "https://demo.example/mitra10/product-3",
+        "name": "Demo Bricks 1pc",
+        "price": 2000,
+        "unit": "pc",
+        "location": "Bandung",
+        "category": CATEGORY_HARDWARE,
+    },
+    {
+        "model": Mitra10Product,
+        "url": "https://demo.example/mitra10/product-4",
+        "name": "Demo Bricks 1pc - Jakarta",
+        "price": 2100,
+        "unit": "pc",
+        "location": "Jakarta",
+        "category": CATEGORY_HARDWARE,
+    },
+    {
+        "model": TokopediaProduct,
+        "url": TOKOPEDIA_P1,
+        "name": "Demo Paint 5L",
+        "price": 150000,
+        "unit": "ltr",
+        "location": "Surabaya",
+        "category": CATEGORY_PAINTS,
+    },
+    {
+        "model": TokopediaProduct,
+        "url": "https://demo.example/tokopedia/product-2",
+        "name": "Demo Paint 5L - Jakarta",
+        "price": 148000,
+        "unit": "ltr",
+        "location": "Jakarta",
+        "category": CATEGORY_PAINTS,
+    },
+    {
+        "model": TokopediaProduct,
+        "url": "https://demo.example/tokopedia/product-3",
+        "name": "Demo Roller 9in",
+        "price": 25000,
+        "unit": "pcs",
+        "location": "Surabaya",
+        "category": CATEGORY_HARDWARE,
+    },
+    {
+        "model": TokopediaProduct,
+        "url": "https://demo.example/tokopedia/product-4",
+        "name": "Demo Roller 9in - Jakarta",
+        "price": 25500,
+        "unit": "pcs",
+        "location": "Jakarta",
+        "category": CATEGORY_HARDWARE,
+    },
+    {
+        "model": DepoBangunanProduct,
+        "url": DEPO_P1,
+        "name": "Demo Tile 30x30",
+        "price": 45000,
+        "unit": "box",
+        "location": "Semarang",
+        "category": CATEGORY_TILES,
+    },
+    {
+        "model": DepoBangunanProduct,
+        "url": "https://demo.example/depobangunan/product-2",
+        "name": "Demo Tile 30x30 - Jakarta",
+        "price": 46000,
+        "unit": "box",
+        "location": "Jakarta",
+        "category": CATEGORY_TILES,
+    },
+    {
+        "model": DepoBangunanProduct,
+        "url": "https://demo.example/depobangunan/product-3",
+        "name": "Demo Cement 20kg",
+        "price": 38000,
+        "unit": "bag",
+        "location": "Semarang",
+        "category": CATEGORY_BUILDING_MATERIALS,
+    },
+    {
+        "model": DepoBangunanProduct,
+        "url": "https://demo.example/depobangunan/product-4",
+        "name": "Demo Cement 20kg - Jakarta",
+        "price": 39000,
+        "unit": "bag",
+        "location": "Jakarta",
+        "category": CATEGORY_BUILDING_MATERIALS,
+    },
+    {
+        "model": JuraganMaterialProduct,
+        "url": "https://demo.example/juragan/product-1",
+        "name": "Demo Gravel 1m3",
+        "price": 250000,
+        "unit": "m3",
+        "location": "Yogyakarta",
+        "category": CATEGORY_AGGREGATES,
+    },
+    {
+        "model": JuraganMaterialProduct,
+        "url": "https://demo.example/juragan/product-2",
+        "name": "Demo Gravel 1m3 - Jakarta",
+        "price": 255000,
+        "unit": "m3",
+        "location": "Jakarta",
+        "category": CATEGORY_AGGREGATES,
+    },
+    {
+        "model": JuraganMaterialProduct,
+        "url": "https://demo.example/juragan/product-3",
+        "name": "Demo Sand 1m3",
+        "price": 120000,
+        "unit": "m3",
+        "location": "Yogyakarta",
+        "category": CATEGORY_BUILDING_MATERIALS,
+    },
+    {
+        "model": JuraganMaterialProduct,
+        "url": "https://demo.example/juragan/product-4",
+        "name": "Demo Sand 1m3 - Jakarta",
+        "price": 125000,
+        "unit": "m3",
+        "location": "Jakarta",
+        "category": CATEGORY_BUILDING_MATERIALS,
+    },
+]
+
+# Demo anomalies (use vendor codes defined in PriceAnomaly.VENDOR_CHOICES)
+DEMO_ANOMALIES = [
+    {
+        "vendor": "gemilang",
+        "product_name": "Demo Nails 1kg",
+        "product_url": GEMILANG_P1,
+        "unit": "kg",
+        "location": "Jakarta",
+        "old_price": 10000,
+        "new_price": 12000,
+        "change_percent": 20.00,
+        "status": "pending",
+        "notes": "Demo increase",
+    },
+    {
+        "vendor": "mitra10",
+        "product_name": "Demo Cement 40kg",
+        "product_url": MITRA10_P1,
+        "unit": "pack",
+        "location": "Bandung",
+        "old_price": 75000,
+        "new_price": 60000,
+        "change_percent": -20.00,
+        "status": "pending",
+        "notes": "Demo decrease (updated to -20%)",
+    },
+    {
+        "vendor": "tokopedia",
+        "product_name": "Demo Paint 5L",
+        "product_url": TOKOPEDIA_P1,
+        "unit": "ltr",
+        "location": "Surabaya",
+        "old_price": 150000,
+        "new_price": 172500,
+        "change_percent": 15.00,
+        "status": "reviewed",
+        "notes": "Small increase — review ok",
+    },
+    {
+        "vendor": "depobangunan",
+        "product_name": "Demo Tile 30x30",
+        "product_url": DEPO_P1,
+        "unit": "box",
+        "location": "Semarang",
+        "old_price": 45000,
+        "new_price": 90000,
+        "change_percent": 100.00,
+        "status": "rejected",
+        "notes": "Large increase detected — rejected",
+    },
+    {
+        "vendor": "mitra10",
+        "product_name": "Demo Cement 40kg - Jakarta (approved 40%)",
+        "product_url": MITRA10_P2,
+        "unit": "pack",
+        "location": "Jakarta",
+        "old_price": 76000,
+        "new_price": 106400,
+        "change_percent": 40.00,
+        "status": "approved",
+        "notes": "Approved large increase (40%)",
+    },
+    {
+        "vendor": "gemilang",
+        "product_name": "Demo Nails 1kg (duplicate case)",
+        "product_url": "https://demo.example/gemilang/product-1",
+        "unit": "kg",
+        "location": "Jakarta",
+        "old_price": 10000,
+        "new_price": 13000,
+        "change_percent": 30.00,
+        "status": "pending",
+        "notes": "Duplicate anomaly attempt — tests idempotency",
+    },
+]
+
+
+class Command(BaseCommand):
+    help = "Idempotently seed demo products and price anomalies"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--force",
+            action="store_true",
+            help="Force re-create anomalies even if they exist (does not delete existing products)",
+        )
+
+    def handle(self, *args, **options):
+        force = options.get("force", False)
+
+        if not self._env_allows_seed():
+            self.stdout.write(self.style.ERROR(
+                "Refusing to run demo seeder: DEBUG is False and DEMO_SEED is not enabled.\n"
+                "To override set environment variable ALLOW_DEMO_ON_PRODUCTION=true (not recommended for production)."
+            ))
+            return
+
+        now = timezone.now()
+        with transaction.atomic():
+            created_products, updated_products = self._seed_products(now)
+            anomalies_created, anomalies_updated = self._seed_anomalies(now, force)
+
+        self.stdout.write(self.style.SUCCESS(
+            f"Seed complete: products(created={created_products}, updated={updated_products}); anomalies(created={anomalies_created}, updated={anomalies_updated})"
+        ))
+
+    def _env_allows_seed(self) -> bool:
+        """Return True if seeding is allowed in current environment."""
+        return (
+            getattr(settings, "DEBUG", False)
+            or getattr(settings, "DEMO_SEED", False)
+            or (os.environ.get("ALLOW_DEMO_ON_PRODUCTION", "").lower() in ("1", "true", "yes"))
+        )
+
+    def _seed_products(self, now):
+        created = 0
+        updated = 0
+        for p in DEMO_PRODUCTS:
+            model = p["model"]
+            url = p["url"]
+            defaults = {
+                "name": p["name"],
+                "price": p["price"],
+                "unit": p.get("unit", ""),
+                "location": p.get("location", ""),
+                "category": p.get("category", ""),
+                "updated_at": now,
+            }
+            _, created_flag = model.objects.update_or_create(url=url, defaults=defaults)
+            if created_flag:
+                created += 1
+            else:
+                updated += 1
+        return created, updated
+
+    def _seed_anomalies(self, now, force):
+        created = 0
+        updated = 0
+        for idx, pa in enumerate(DEMO_ANOMALIES):
+            lookup = {"product_url": pa["product_url"], "vendor": pa["vendor"]}
+            defaults = {
+                "product_name": pa["product_name"],
+                "unit": pa.get("unit", ""),
+                "location": pa.get("location", ""),
+                "old_price": pa["old_price"],
+                "new_price": pa["new_price"],
+                "change_percent": pa["change_percent"],
+                "status": pa.get("status", "pending"),
+                "notes": pa.get("notes", ""),
+            }
+
+            if defaults.get("status") and defaults["status"] != "pending":
+                defaults["reviewed_at"] = (now + timedelta(minutes=5 * (idx + 1)))
+
+            if force:
+                PriceAnomaly.objects.filter(**lookup).delete()
+                _ = PriceAnomaly.objects.create(**{**lookup, **defaults})
+                created += 1
+            else:
+                _, created_flag = PriceAnomaly.objects.update_or_create(defaults=defaults, **lookup)
+                if created_flag:
+                    created += 1
+                else:
+                    updated += 1
+
+        return created, updated

--- a/db_pricing/tests/test_seed_demo_data.py
+++ b/db_pricing/tests/test_seed_demo_data.py
@@ -1,0 +1,206 @@
+import io
+import os
+from unittest.mock import Mock
+import argparse
+from django.test import TestCase
+from django.conf import settings
+
+import db_pricing.management.commands.seed_demo_data as sd
+
+
+class TestSeedDemoData(TestCase):
+    def setUp(self):
+        # preserve original settings and env var
+        self._orig_debug = getattr(settings, 'DEBUG', None)
+        self._orig_demo = getattr(settings, 'DEMO_SEED', None)
+        self._orig_allow = os.environ.get('ALLOW_DEMO_ON_PRODUCTION')
+
+    def tearDown(self):
+        # Restore DEBUG (remove if it did not exist originally)
+        if self._orig_debug is None:
+            try:
+                delattr(settings, 'DEBUG')
+            except Exception:
+                pass
+        else:
+            settings.DEBUG = self._orig_debug
+
+        # Restore DEMO_SEED (remove if it did not exist originally)
+        if self._orig_demo is None:
+            try:
+                delattr(settings, 'DEMO_SEED')
+            except Exception:
+                pass
+        else:
+            settings.DEMO_SEED = self._orig_demo
+        if self._orig_allow is None:
+            os.environ.pop('ALLOW_DEMO_ON_PRODUCTION', None)
+        else:
+            os.environ['ALLOW_DEMO_ON_PRODUCTION'] = self._orig_allow
+
+    def test_env_guard_blocks_when_not_allowed(self):
+        # Ensure seeder refuses to run when DEBUG=False and DEMO_SEED=False and no override
+        settings.DEBUG = False
+        settings.DEMO_SEED = False
+        os.environ.pop('ALLOW_DEMO_ON_PRODUCTION', None)
+
+        cmd = sd.Command()
+        out = io.StringIO()
+        cmd.stdout = out
+
+        cmd.handle()
+
+        self.assertIn('Refusing to run demo seeder', out.getvalue())
+
+    def test_seed_products_calls_update_or_create(self):
+        # Patch all vendor product model classes in module to have a mock manager
+        mock_mgr = Mock()
+        mock_mgr.update_or_create.return_value = (object(), True)
+
+        fake_model = Mock()
+        fake_model.objects = mock_mgr
+        # Replace DEMO_PRODUCTS with a short test list that uses our fake_model
+        orig_products = sd.DEMO_PRODUCTS
+        test_products = [
+            {"model": fake_model, "url": "u1", "name": "n1", "price": 1},
+            {"model": fake_model, "url": "u2", "name": "n2", "price": 2},
+            {"model": fake_model, "url": "u3", "name": "n3", "price": 3},
+        ]
+        sd.DEMO_PRODUCTS = test_products
+
+        cmd = sd.Command()
+        now = sd.timezone.now()
+        created, updated = cmd._seed_products(now)
+
+        # update_or_create should be called once per DEMO_PRODUCTS entry
+        self.assertEqual(mock_mgr.update_or_create.call_count, len(test_products))
+        self.assertEqual(created, len(test_products))
+        self.assertEqual(updated, 0)
+        # restore
+        sd.DEMO_PRODUCTS = orig_products
+
+    def test_seed_anomalies_force_uses_create(self):
+        # Patch PriceAnomaly manager methods
+        pa_mgr = Mock()
+        pa_mgr.filter.return_value.delete = Mock()
+        pa_mgr.create = Mock()
+
+        setattr(sd, 'PriceAnomaly', Mock(objects=pa_mgr))
+
+        cmd = sd.Command()
+        now = sd.timezone.now()
+        created, updated = cmd._seed_anomalies(now, force=True)
+
+        # For force=True, create() should be called for each anomaly
+        self.assertEqual(pa_mgr.create.call_count, len(sd.DEMO_ANOMALIES))
+        self.assertEqual(created, len(sd.DEMO_ANOMALIES))
+        self.assertEqual(updated, 0)
+
+    def test_seed_anomalies_sets_reviewed_at_for_non_pending(self):
+        # Patch update_or_create to capture defaults passed
+        calls = []
+
+        def fake_update_or_create(defaults=None, **lookup):
+            # store a shallow copy of defaults for inspection
+            calls.append(defaults.copy() if defaults is not None else {})
+            return (object(), True)
+
+        pa_mgr = Mock()
+        pa_mgr.update_or_create.side_effect = fake_update_or_create
+
+        setattr(sd, 'PriceAnomaly', Mock(objects=pa_mgr))
+
+        cmd = sd.Command()
+        now = sd.timezone.now()
+        created, updated = cmd._seed_anomalies(now, force=False)
+
+        self.assertEqual(created + updated, len(sd.DEMO_ANOMALIES))
+
+        # Every defaults for anomalies whose status != 'pending' should contain 'reviewed_at'
+        for pa, defaults in zip(sd.DEMO_ANOMALIES, calls):
+            if pa.get('status', 'pending') != 'pending':
+                self.assertIn('reviewed_at', defaults)
+            else:
+                self.assertNotIn('reviewed_at', defaults)
+
+    def test_handle_runs_when_env_allows(self):
+        settings.DEBUG = True
+        settings.DEMO_SEED = False
+
+        cmd = sd.Command()
+        out = io.StringIO()
+        cmd.stdout = out
+
+        # Patch helper methods to not touch DB
+        setattr(cmd, '_seed_products', lambda now: (1, 2))
+        setattr(cmd, '_seed_anomalies', lambda now, force: (3, 4))
+
+        cmd.handle()
+
+        output = out.getvalue()
+        self.assertIn('Seed complete', output)
+        self.assertIn('products(created=1, updated=2)', output)
+        self.assertIn('anomalies(created=3, updated=4)', output)
+
+    def test_env_allows_via_allow_env_var(self):
+        # When DEBUG and DEMO_SEED are False, ALLOW_DEMO_ON_PRODUCTION env var should allow seeding
+        settings.DEBUG = False
+        settings.DEMO_SEED = False
+        os.environ['ALLOW_DEMO_ON_PRODUCTION'] = 'true'
+
+        cmd = sd.Command()
+        out = io.StringIO()
+        cmd.stdout = out
+
+        # Patch helper methods to avoid DB operations
+        setattr(cmd, '_seed_products', lambda now: (0, 0))
+        setattr(cmd, '_seed_anomalies', lambda now, force: (0, 0))
+
+        cmd.handle()
+
+        self.assertIn('Seed complete', out.getvalue())
+
+    def test_seed_products_handles_updates(self):
+        # Simulate update_or_create returning created_flag=False to exercise 'updated' branch
+        mock_mgr = Mock()
+        mock_mgr.update_or_create.return_value = (object(), False)
+
+        fake_model = Mock()
+        fake_model.objects = mock_mgr
+
+        orig_products = sd.DEMO_PRODUCTS
+        test_products = [
+            {"model": fake_model, "url": "u1", "name": "n1", "price": 1},
+            {"model": fake_model, "url": "u2", "name": "n2", "price": 2},
+        ]
+        sd.DEMO_PRODUCTS = test_products
+
+        cmd = sd.Command()
+        now = sd.timezone.now()
+        created, updated = cmd._seed_products(now)
+
+        self.assertEqual(created, 0)
+        self.assertEqual(updated, len(test_products))
+
+        sd.DEMO_PRODUCTS = orig_products
+
+    def test_seed_anomalies_handles_updates(self):
+        # Patch update_or_create to return created_flag=False for anomalies
+        pa_mgr = Mock()
+        pa_mgr.update_or_create.return_value = (object(), False)
+        setattr(sd, 'PriceAnomaly', Mock(objects=pa_mgr))
+
+        cmd = sd.Command()
+        now = sd.timezone.now()
+        created, updated = cmd._seed_anomalies(now, force=False)
+
+        self.assertEqual(created, 0)
+        self.assertEqual(updated, len(sd.DEMO_ANOMALIES))
+
+    def test_add_arguments_registers_force(self):
+        cmd = sd.Command()
+        parser = argparse.ArgumentParser()
+        # Should not raise and should accept --force
+        cmd.add_arguments(parser)
+        ns = parser.parse_args(["--force"])
+        self.assertTrue(getattr(ns, 'force', False))

--- a/price_scraper_rencanakan_api/settings.py
+++ b/price_scraper_rencanakan_api/settings.py
@@ -203,3 +203,5 @@ CSRF_TRUSTED_ORIGINS = env.list('CSRF_TRUSTED_ORIGINS', default=[])
 TEST_IP_ALLOWED = env.str('TEST_IP_ALLOWED')
 TEST_IP_DENIED = env.str('TEST_IP_DENIED')
 TEST_IP_ATTACKER = env.str('TEST_IP_ATTACKER')
+
+DEMO_SEED = env.bool("DEMO_SEED", default=False)


### PR DESCRIPTION
This PR adds a data seeding command to add dummy data to the database configured in your environment. This command has been integrated into the CI CD for data seeding in the deployment environments.

Data seeded: Vendor records and price anomaly records (multiple vendors / products / locations / categories, including a mix of pending and reviewed anomalies).

The main purpose is to provide realistic demo data to showcase the price-anomaly feature during demos without manual data creation.

How to run locally:
Option A (recommended): add DEMO_SEED=true to your project .env, then:
python manage.py seed_demo_data

Option B (ephemeral): prefix the command:
DEMO_SEED=true python manage.py seed_demo_data

To force recreate anomalies:
DEMO_SEED=true python manage.py seed_demo_data --force